### PR TITLE
Add simple Pomodoro timer with tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
-# codex-test
+# Pomodoro Timer
+
+Bu depo, Pomodoro tekniğini takip eden basit bir Python zamanlayıcısı içerir.
+Zamanlayıcı otomatik veya manuel geçişlerle çalışma, kısa mola ve uzun mola
+oturumları arasında döngü yapabilir.
+
+## Çalıştırma
+
+```bash
+python -m pomodoro.cli
+```
+
+Varsayılan değerler 25/5/15 dakikadır. Süreleri ve döngü sayısını ayarlamak
+ için `--work`, `--short`, `--long`, `--cycles` bayraklarını kullanın. Manuel geçiş
+ için `--manual` bayrağını ekleyin.
+
+## Testler
+
+```bash
+python -m unittest discover -s tests -p "test_*.py"
+```
+
+Ünite testleri zamanlayıcı mantığının doğru çalıştığını doğrular.

--- a/pomodoro/cli.py
+++ b/pomodoro/cli.py
@@ -1,0 +1,44 @@
+"""Simple command-line interface for PomodoroTimer."""
+import argparse
+import time
+from .timer import PomodoroTimer, PomodoroConfig, Phase
+
+
+def format_time(seconds: int) -> str:
+    m, s = divmod(max(0, int(seconds)), 60)
+    return f"{m:02d}:{s:02d}"
+
+
+def run_timer(config: PomodoroConfig) -> None:
+    timer = PomodoroTimer(config)
+    timer.start()
+    try:
+        while True:
+            print(f"{timer.current_phase().name}: {format_time(timer.remaining)}", end="\r")
+            time.sleep(1)
+            timer.tick(1)
+    except KeyboardInterrupt:
+        print("\nTimer stopped")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run a Pomodoro timer")
+    parser.add_argument("--work", type=int, default=25, help="work minutes")
+    parser.add_argument("--short", type=int, default=5, help="short break minutes")
+    parser.add_argument("--long", type=int, default=15, help="long break minutes")
+    parser.add_argument("--cycles", type=int, default=4, help="cycles before long break")
+    parser.add_argument("--manual", action="store_true", help="disable auto transitions")
+    args = parser.parse_args()
+
+    config = PomodoroConfig(
+        work_minutes=args.work,
+        short_break_minutes=args.short,
+        long_break_minutes=args.long,
+        cycles_before_long_break=args.cycles,
+        auto_transition=not args.manual,
+    )
+    run_timer(config)
+
+
+if __name__ == "__main__":
+    main()

--- a/pomodoro/timer.py
+++ b/pomodoro/timer.py
@@ -1,0 +1,103 @@
+"""Pomodoro timer core service.
+
+Provides epoch-based ticking and session cycling following the Pomodoro technique.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum, auto
+
+
+class Phase(Enum):
+    """Different phases of a Pomodoro cycle."""
+
+    FOCUS = auto()
+    SHORT_BREAK = auto()
+    LONG_BREAK = auto()
+
+
+@dataclass
+class PomodoroConfig:
+    work_minutes: int = 25
+    short_break_minutes: int = 5
+    long_break_minutes: int = 15
+    cycles_before_long_break: int = 4
+    auto_transition: bool = True
+
+
+class PomodoroTimer:
+    """A simple timer implementing basic Pomodoro logic.
+
+    The timer is **tick based** – tests can advance time deterministically by
+    calling :meth:`tick` instead of waiting in real time.
+    """
+
+    def __init__(self, config: PomodoroConfig | None = None):
+        self.config = config or PomodoroConfig()
+        self.phase: Phase = Phase.FOCUS
+        self.state: str = "idle"  # idle | running | paused
+        self.remaining: int = self.config.work_minutes * 60
+        self._cycle_count: int = 0  # completed focus sessions in current set
+
+    # Public API -----------------------------------------------------------
+    def start(self) -> None:
+        """Start or resume the current phase."""
+        if self.state in {"idle", "paused"}:
+            self.state = "running"
+
+    def pause(self) -> None:
+        if self.state == "running":
+            self.state = "paused"
+
+    def tick(self, seconds: int) -> None:
+        """Advance the timer by ``seconds``.
+
+        When ``auto_transition`` is disabled and a phase completes, the timer
+        stops with ``state='idle'`` and the next phase is prepared but not
+        started until :meth:`start` is called again.
+        """
+        if self.state != "running":
+            return
+        self.remaining -= seconds
+        while self.remaining <= 0 and self.state == "running":
+            self._complete_phase()
+
+    # Internal helpers ----------------------------------------------------
+    def _complete_phase(self) -> None:
+        """Handle completion of the current phase."""
+        overflow = -self.remaining
+        if self.phase == Phase.FOCUS:
+            self._cycle_count += 1
+            if self._cycle_count % self.config.cycles_before_long_break == 0:
+                next_phase = Phase.LONG_BREAK
+                duration = self.config.long_break_minutes * 60
+                self._cycle_count = 0
+            else:
+                next_phase = Phase.SHORT_BREAK
+                duration = self.config.short_break_minutes * 60
+        elif self.phase in {Phase.SHORT_BREAK, Phase.LONG_BREAK}:
+            next_phase = Phase.FOCUS
+            duration = self.config.work_minutes * 60
+        else:
+            next_phase = Phase.FOCUS
+            duration = self.config.work_minutes * 60
+
+        self.phase = next_phase
+        self.remaining = duration + overflow  # carry over extra seconds
+        if self.config.auto_transition:
+            self.state = "running"
+        else:
+            self.state = "idle"
+
+    def is_running(self) -> bool:
+        return self.state == "running"
+
+    def current_phase(self) -> Phase:
+        return self.phase
+
+    def reset(self) -> None:
+        """Reset timer to initial focus phase."""
+        self.phase = Phase.FOCUS
+        self.state = "idle"
+        self.remaining = self.config.work_minutes * 60
+        self._cycle_count = 0

--- a/tests/test_timer.py
+++ b/tests/test_timer.py
@@ -1,0 +1,38 @@
+import unittest
+from pomodoro.timer import PomodoroTimer, PomodoroConfig, Phase
+
+
+class TestPomodoroTimer(unittest.TestCase):
+    def test_auto_transition_cycle(self):
+        config = PomodoroConfig(
+            work_minutes=1,
+            short_break_minutes=1,
+            long_break_minutes=2,
+            cycles_before_long_break=2,
+            auto_transition=True,
+        )
+        timer = PomodoroTimer(config)
+        timer.start()
+        timer.tick(60)  # complete focus
+        self.assertEqual(timer.current_phase(), Phase.SHORT_BREAK)
+        self.assertTrue(timer.is_running())
+        timer.tick(60)  # complete short break
+        self.assertEqual(timer.current_phase(), Phase.FOCUS)
+        timer.tick(60)  # complete second focus -> long break
+        self.assertEqual(timer.current_phase(), Phase.LONG_BREAK)
+        timer.tick(120)  # complete long break
+        self.assertEqual(timer.current_phase(), Phase.FOCUS)
+
+    def test_manual_transition(self):
+        config = PomodoroConfig(work_minutes=1, short_break_minutes=1, auto_transition=False)
+        timer = PomodoroTimer(config)
+        timer.start()
+        timer.tick(60)  # complete focus
+        self.assertEqual(timer.current_phase(), Phase.SHORT_BREAK)
+        self.assertFalse(timer.is_running())
+        timer.start()  # manually start break
+        self.assertTrue(timer.is_running())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement tick-based Pomodoro timer supporting auto/manual session transitions
- expose CLI for running the timer and configuring durations
- add unit tests for session cycling logic

## Testing
- `python -m unittest discover -s tests -p "test_*.py"`

------
https://chatgpt.com/codex/tasks/task_e_6891c694af2c832fb4a12673faa1293f